### PR TITLE
feat: use the org subgraph

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -99,7 +99,7 @@ const Index = () => {
   useEffect(() => {
     const fetchData = async () => {
       const response = await axios.post(
-        'https://api.thegraph.com/subgraphs/name/greenlucid/legacy-curate-xdai',
+        'https://api.thegraph.com/subgraphs/name/kleros/legacy-curate-xdai',
         {
           query: `
           {

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -101,7 +101,7 @@ const fetchGraphQLData = async (variables: {
   }
   `;
   const response = await fetch(
-    'https://api.thegraph.com/subgraphs/name/greenlucid/legacy-curate-xdai',
+    'https://api.thegraph.com/subgraphs/name/kleros/legacy-curate-xdai',
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Switching to the subgraph under the kleros org account:

https://thegraph.com/hosted-service/subgraph/kleros/legacy-curate-xdai

https://api.thegraph.com/subgraphs/name/kleros/legacy-curate-xdai